### PR TITLE
Add ADO PR autolinks based on merge message

### DIFF
--- a/src/git/remotes/azure-devops.ts
+++ b/src/git/remotes/azure-devops.ts
@@ -46,12 +46,18 @@ export class AzureDevOpsRemote extends RemoteProvider {
 	get autolinks(): (AutolinkReference | DynamicAutolinkReference)[] {
 		if (this._autolinks === undefined) {
 			// Strip off any `_git` part from the repo url
-			const baseUrl = this.baseUrl.replace(gitRegex, '/');
+			const workUrl = this.baseUrl.replace(gitRegex, '/');
 			this._autolinks = [
 				{
 					prefix: '#',
-					url: `${baseUrl}/_workitems/edit/<num>`,
+					url: `${workUrl}/_workitems/edit/<num>`,
 					title: `Open Work Item #<num> on ${this.name}`,
+				},
+				{
+					// Default Pull request message when merging a PR in ADO. Will not catch commits & pushes following a different pattern.
+					prefix: 'Merged PR ',
+					url: `${this.baseUrl}/pullrequest/<num>`,
+					title: `Open Pull Request #<num> on ${this.name}`,
 				},
 			];
 		}


### PR DESCRIPTION
# Description
Closes #1486 Adds autolinks for merged Azure Devops PRs with default messages.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
