### PR TITLE
Adds isFileSystemResource to when clauses. Closes #1583.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6752,39 +6752,39 @@
 			"editor/title/context": [
 				{
 					"command": "gitlens.copyRemoteFileUrlWithoutRange",
-					"when": "gitlens:enabled && gitlens:hasRemotes && config.gitlens.menus.editorTab.clipboard",
+					"when": "gitlens:enabled && gitlens:hasRemotes && config.gitlens.menus.editorTab.clipboard && isFileSystemResource",
 					"group": "1_cutcopypaste@100"
 				},
 				{
 					"submenu": "gitlens/editor/changes",
-					"when": "gitlens:enabled && config.gitlens.menus.editorTab.compare",
+					"when": "gitlens:enabled && config.gitlens.menus.editorTab.compare && isFileSystemResource",
 					"group": "2_gitlens@0"
 				},
 				{
 					"command": "gitlens.openWorkingFile",
-					"when": "resourceScheme == gitlens",
+					"when": "resourceScheme == gitlens && isFileSystemResource",
 					"group": "2_gitlens@1"
 				},
 				{
 					"command": "gitlens.openFileOnRemote",
-					"when": "gitlens:enabled && gitlens:hasRemotes && config.gitlens.menus.editorTab.remote",
+					"when": "gitlens:enabled && gitlens:hasRemotes && config.gitlens.menus.editorTab.remote && isFileSystemResource",
 					"group": "2_gitlens@2",
 					"alt": "gitlens.copyRemoteFileUrlWithoutRange"
 				},
 				{
 					"command": "gitlens.openFileOnRemoteFrom",
-					"when": "gitlens:enabled && gitlens:hasRemotes && config.gitlens.menus.editorTab.remote",
+					"when": "gitlens:enabled && gitlens:hasRemotes && config.gitlens.menus.editorTab.remote && isFileSystemResource",
 					"group": "2_gitlens@3",
 					"alt": "gitlens.copyRemoteFileUrlFrom"
 				},
 				{
 					"command": "gitlens.openFileHistory",
-					"when": "gitlens:enabled && config.gitlens.menus.editorTab.history",
+					"when": "gitlens:enabled && config.gitlens.menus.editorTab.history && isFileSystemResource",
 					"group": "2_gitlens_1@1"
 				},
 				{
 					"command": "gitlens.quickOpenFileHistory",
-					"when": "gitlens:enabled && config.gitlens.menus.editorTab.history",
+					"when": "gitlens:enabled && config.gitlens.menus.editorTab.history && isFileSystemResource",
 					"group": "2_gitlens_1@2"
 				}
 			],


### PR DESCRIPTION
# Description

Adds isFileSystemResource to when clauses. Closes #1583.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x]  My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
