### PR TITLE
Fixes #1609 execute context.globalState.setKeysForSync only if it exists

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -197,7 +197,7 @@ export async function setEnabled(enabled: boolean): Promise<void> {
 }
 
 export function setKeysForSync(...keys: (SyncedState | string)[]) {
-	return _context?.globalState.setKeysForSync([...keys, SyncedState.Version, SyncedState.WelcomeViewVisible]);
+	return _context?.globalState?.setKeysForSync([...keys, SyncedState.Version, SyncedState.WelcomeViewVisible]);
 }
 
 export function notifyOnUnsupportedGitVersion(version: string) {


### PR DESCRIPTION
fix for : https://github.com/eamodio/vscode-gitlens/issues/1609
