### PR TITLE
Fixes #1178: adds '--no-ff --no-commit' option to merge

### DIFF
--- a/src/commands/git/merge.ts
+++ b/src/commands/git/merge.ts
@@ -29,7 +29,7 @@ interface Context {
 	title: string;
 }
 
-type Flags = '--ff-only' | '--no-ff' | '--squash';
+type Flags = '--ff-only' | '--no-ff' | '--squash' | '--no-commit' ;
 
 interface State {
 	repo: string | Repository;
@@ -235,6 +235,16 @@ export class MergeGitCommand extends QuickCommand<State> {
 					label: `No Fast-forward ${this.title}`,
 					description: '--no-ff',
 					detail: `Will create a merge commit when merging ${Strings.pluralize(
+						'commit',
+						count,
+					)} from ${GitReference.toString(state.reference)} into ${GitReference.toString(
+						context.destination,
+					)}`,
+				}),
+				FlagsQuickPickItem.create<Flags>(state.flags, ['--no-ff', '--no-commit'], {
+					label: `No Fast-forward and no commit ${this.title}`,
+					description: '--no-ff --no-commit',
+					detail: `Will stop before making commit when merging ${Strings.pluralize(
 						'commit',
 						count,
 					)} from ${GitReference.toString(state.reference)} into ${GitReference.toString(


### PR DESCRIPTION
---

# Description

This change just adds '--no-ff --no-commit' option to merge command.  
I personally use it all the time to review the code.  

Merge without commit, see problems, reset.  

Issue for that #1178 was created some time ago, but it seems it did not get any traction.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
